### PR TITLE
Avoid predicting a new address if there's already one registered

### DIFF
--- a/safe_relay_service/relay/services/safe_creation_service.py
+++ b/safe_relay_service/relay/services/safe_creation_service.py
@@ -155,7 +155,8 @@ class SafeCreationService:
 
     def existing_predicted_address(self, salt_nonce: int, owners: Iterable[str]) -> str:
         """
-        Return a previously predicted Safe address
+        Return a previously predicted Safe address.
+        Note that the prediction parameters are not updated for the SafeCreation2 object
         :param salt_nonce: Random value for solidity `create2` salt
         :param owners: Owners of the new Safe
         :rtype: str
@@ -164,8 +165,6 @@ class SafeCreationService:
             safe_creation = SafeCreation2.objects.filter(owners__contains=owners).order_by('created').first()
             assert salt_nonce == safe_creation.salt_nonce, 'Existing predicted address salt_nonce should be the same!'
             predicted_safe_address = safe_creation.safe_id
-            safe_creation.payment_receiver = self.funder_account.address
-            safe_creation.save(update_fields=['payment_receiver'])
             logger.info('The relayer had already predicted an address for this owner. Safe addr: %s, owner: %s', predicted_safe_address, owners)
             return predicted_safe_address
         except SafeCreation2.DoesNotExist:

--- a/safe_relay_service/relay/services/safe_creation_service.py
+++ b/safe_relay_service/relay/services/safe_creation_service.py
@@ -162,11 +162,12 @@ class SafeCreationService:
         :rtype: str
         """
         try:
-            safe_creation = SafeCreation2.objects.filter(owners__contains=owners).order_by('created').first()
-            assert salt_nonce == safe_creation.salt_nonce, 'Existing predicted address salt_nonce should be the same!'
-            predicted_safe_address = safe_creation.safe_id
-            logger.info('The relayer had already predicted an address for this owner. Safe addr: %s, owner: %s', predicted_safe_address, owners)
-            return predicted_safe_address
+            # The salt_nonce is deterministicly generated from the owner address
+            safe_creation = SafeCreation2.objects.filter(owners__contains=owners, salt_nonce=salt_nonce).order_by('created').first()
+            if not safe_creation:
+                return NULL_ADDRESS
+            logger.info('The relayer had already predicted an address for this owner. Safe addr: %s, owner: %s', safe_creation.safe_id, owners)
+            return safe_creation.safe_id
         except SafeCreation2.DoesNotExist:
             return NULL_ADDRESS
 

--- a/safe_relay_service/relay/views_v3.py
+++ b/safe_relay_service/relay/views_v3.py
@@ -59,7 +59,9 @@ class SafeAddressPredictionView(CreateAPIView):
                                                             serializer.data['payment_token'])
 
             safe_creation_service = SafeCreationServiceProvider()
-            safe_prediction = safe_creation_service.predict_address(salt_nonce, owners, threshold, payment_token)
+            safe_prediction = safe_creation_service.existing_predicted_address(salt_nonce, owners)
+            if safe_prediction == NULL_ADDRESS:
+                safe_prediction = safe_creation_service.predict_address(salt_nonce, owners)
             safe_prediction_response_data = SafeAddressPredictionResponseSerializer(data={
                 'safe': safe_prediction,
             })

--- a/safe_relay_service/relay/views_v3.py
+++ b/safe_relay_service/relay/views_v3.py
@@ -61,7 +61,7 @@ class SafeAddressPredictionView(CreateAPIView):
             safe_creation_service = SafeCreationServiceProvider()
             safe_prediction = safe_creation_service.existing_predicted_address(salt_nonce, owners)
             if safe_prediction == NULL_ADDRESS:
-                safe_prediction = safe_creation_service.predict_address(salt_nonce, owners)
+                safe_prediction = safe_creation_service.predict_address(salt_nonce, owners, threshold, payment_token)
             safe_prediction_response_data = SafeAddressPredictionResponseSerializer(data={
                 'safe': safe_prediction,
             })

--- a/safe_relay_service/relay/views_v3.py
+++ b/safe_relay_service/relay/views_v3.py
@@ -50,7 +50,7 @@ class SafeAddressPredictionView(CreateAPIView):
                                     422: 'Cannot process data'})
     def post(self, request, *args, **kwargs):
         """
-        Predicts the safe address
+        Predicts the safe address. If the relayer already predicted an address for that owner, it doesn't do the prediction again
         """
         serializer = self.serializer_class(data=request.data)
         if serializer.is_valid():

--- a/safe_relay_service/relay/views_v3.py
+++ b/safe_relay_service/relay/views_v3.py
@@ -50,7 +50,8 @@ class SafeAddressPredictionView(CreateAPIView):
                                     422: 'Cannot process data'})
     def post(self, request, *args, **kwargs):
         """
-        Predicts the safe address. If the relayer already predicted an address for that owner, it doesn't do the prediction again
+        Predicts the safe address. If the relayer already predicted an address for that owner, it doesn't do the prediction again.
+        Note that the prediction parameters are not updated for the SafeCreation2 object
         """
         serializer = self.serializer_class(data=request.data)
         if serializer.is_valid():


### PR DESCRIPTION
This code checks in the database of the relayer if there is already an address predicted for this owner. The address prediction function is performed before the Safe is deployed, and it's important to keep this predicted address for the user in order to keep the onboarding status (e.g. trust connections, username,...).