### PR TITLE
Set version for web3 dependency and fix FeeTooLow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN for i in {1..8}; do mkdir -p "/usr/share/man/man$i"; done
 
 # Install postgres-client
 RUN apt-get update \
-      && apt-get install -y git postgresql-client libpq-dev libxml2-dev libxslt-dev python-dev zlib1g-dev
+      && apt-get install -y git postgresql-client libpq-dev libxml2-dev libxslt-dev zlib1g-dev
 
 WORKDIR safe-relay-service
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,4 +27,4 @@ redis==4.3.4
 requests==2.28.1
 sgqlc==11.0
 safe-eth-py[django]
-web3
+web3==5.31.4

--- a/safe_relay_service/relay/services/safe_creation_service.py
+++ b/safe_relay_service/relay/services/safe_creation_service.py
@@ -366,8 +366,8 @@ class SafeCreationService:
                 safe_creation2.master_copy,
                 setup_data,
                 safe_creation2.salt_nonce,
-                gas=safe_creation2.gas_estimated + 50000000,  # Just in case
-                gas_price=safe_creation2.gas_price_estimated,
+                gas=safe_creation2.gas_estimated + 50000,  # Just in case
+                gas_price=safe_creation2.gas_price_estimated + 1000000000,
                 nonce=tx_nonce,
             )
             EthereumTx.objects.create_from_tx_dict(

--- a/safe_relay_service/relay/services/safe_creation_service.py
+++ b/safe_relay_service/relay/services/safe_creation_service.py
@@ -366,7 +366,7 @@ class SafeCreationService:
                 safe_creation2.master_copy,
                 setup_data,
                 safe_creation2.salt_nonce,
-                gas=safe_creation2.gas_estimated + 50000,  # Just in case
+                gas=safe_creation2.gas_estimated + 500000,  # Just in case
                 gas_price=safe_creation2.gas_price_estimated+8,
                 nonce=tx_nonce,
             )

--- a/safe_relay_service/relay/services/safe_creation_service.py
+++ b/safe_relay_service/relay/services/safe_creation_service.py
@@ -366,7 +366,7 @@ class SafeCreationService:
                 safe_creation2.master_copy,
                 setup_data,
                 safe_creation2.salt_nonce,
-                gas=safe_creation2.gas_estimated + 500000,  # Just in case
+                gas=safe_creation2.gas_estimated + 5000000,  # Just in case
                 gas_price=safe_creation2.gas_price_estimated+8,
                 nonce=tx_nonce,
             )

--- a/safe_relay_service/relay/services/safe_creation_service.py
+++ b/safe_relay_service/relay/services/safe_creation_service.py
@@ -366,8 +366,8 @@ class SafeCreationService:
                 safe_creation2.master_copy,
                 setup_data,
                 safe_creation2.salt_nonce,
-                gas=safe_creation2.gas_estimated + 5000000,  # Just in case
-                gas_price=safe_creation2.gas_price_estimated+8,
+                gas=safe_creation2.gas_estimated + 50000000,  # Just in case
+                gas_price=safe_creation2.gas_price_estimated,
                 nonce=tx_nonce,
             )
             EthereumTx.objects.create_from_tx_dict(

--- a/safe_relay_service/relay/services/transaction_service.py
+++ b/safe_relay_service/relay/services/transaction_service.py
@@ -398,7 +398,7 @@ class TransactionService:
         """
         # Tx data from Circles Hub contract `signup` method
         data = "0xb7bc0f73"
-        return 10000000000000000
+        return 50000000000000000
 
     def estimate_circles_organization_signup_tx(
         self, safe_address: str, gas_token: str = NULL_ADDRESS
@@ -410,7 +410,7 @@ class TransactionService:
         """
         # Tx data from Circles Hub contract organizationSignup method
         data = "0x3fbd653c"
-        return 10000000000000000
+        return 50000000000000000
         # return self.estimate_circles_hub_method(data, safe_address, gas_token)
 
     def create_multisig_tx(


### PR DESCRIPTION
The `FeeTooLow` error is still present.
It seems that the value of gas price is not being used:
```
2023-11-16 22:59:51,047 [ERROR] [ce7d02c9/circles_onboarding_safe_task] Task safe_relay_service.relay.tasks.circles_onboarding_safe_task[ce7d02c9-7b17-48eb-9d4a-c1fa8fcd70ac] raised unexpected: ValueError({'code': -32010, 'message': 'FeeTooLow, EffectivePriorityFeePerGas too low 0 < 1000000000, BaseFee: 9057696534'})
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/celery/app/trace.py", line 451, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/celery/app/trace.py", line 734, in __protected_call__
    return self.run(*args, **kwargs)
  File "/safe-relay-service/safe_relay_service/relay/tasks.py", line 650, in circles_onboarding_safe_task
    SafeCreationServiceProvider().deploy_create2_safe_tx(safe_address)
  File "/safe-relay-service/safe_relay_service/relay/services/safe_creation_service.py", line 364, in deploy_create2_safe_tx
    ethereum_tx_sent = proxy_factory.deploy_proxy_contract_with_nonce(
  File "/usr/local/lib/python3.9/site-packages/gnosis/safe/proxy_factory.py", line 209, in deploy_proxy_contract_with_nonce
    tx_hash = self.ethereum_client.send_unsigned_transaction(
  File "/usr/local/lib/python3.9/site-packages/gnosis/eth/ethereum_client.py", line 1870, in send_unsigned_transaction
    return self.send_raw_transaction(signed_tx.rawTransaction)
  File "/usr/local/lib/python3.9/site-packages/gnosis/eth/ethereum_client.py", line 141, in with_exception_handling
    raise exc
  File "/usr/local/lib/python3.9/site-packages/gnosis/eth/ethereum_client.py", line 135, in with_exception_handling
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/gnosis/eth/ethereum_client.py", line 1819, in send_raw_transaction
    return self.w3.eth.send_raw_transaction(bytes(raw_transaction))
  File "/usr/local/lib/python3.9/site-packages/web3/eth.py", line 831, in send_raw_transaction
    return self._send_raw_transaction(transaction)
  File "/usr/local/lib/python3.9/site-packages/web3/module.py", line 57, in caller
    result = w3.manager.request_blocking(method_str,
  File "/usr/local/lib/python3.9/site-packages/web3/manager.py", line 198, in request_blocking
    return self.formatted_response(response,
  File "/usr/local/lib/python3.9/site-packages/web3/manager.py", line 171, in formatted_response
    raise ValueError(response["error"])
ValueError: {'code': -32010, 'message': 'FeeTooLow, EffectivePriorityFeePerGas too low 0 < 1000000000, BaseFee: 9057696534'}
```